### PR TITLE
Reduce text on mobile action buttons

### DIFF
--- a/app/views/mobile/index.html.erb
+++ b/app/views/mobile/index.html.erb
@@ -270,9 +270,9 @@
 <footer>
   <nav>
     <div class="when-not-editing">
-      <a href="<%= mobile_launch_url %>" class="button">Add App</a>
-      <a href="#" data-start-rearrange-apps class="button">Rearrange Apps</a>
-      <a href="#" data-start-delete-apps class="button">Delete Apps</a>
+      <a href="<%= mobile_launch_url %>" class="button">Add</a>
+      <a href="#" data-start-rearrange-apps class="button">Rearrange</a>
+      <a href="#" data-start-delete-apps class="button">Delete</a>
     </div>
     <div class="when-editing">
       <a href="#" data-stop-edit-apps class="button">Stop Editing</a>


### PR DESCRIPTION
Per @rrocchio:

> can you shorten the buttons on the bottom to say "Add", "Rearrange" and "Delete", instead of having the "trailing 'Apps'"...
