### PR TITLE
LTI Attributes Always As Object

### DIFF
--- a/app/models/casa/attribute/lti.rb
+++ b/app/models/casa/attribute/lti.rb
@@ -17,7 +17,7 @@ module Casa
             data['registration_url'] = app.lti_registration_url if app.lti_registration_url
             data['versions_supported'] = app.app_lti_versions.map(){ |r| r.version } if app.app_lti_versions.length > 0
             data['outcomes'] = app.lti_outcomes if app.lti_outcomes
-            data.keys.length > 0 ? data : true
+            data
           else
             nil
           end


### PR DESCRIPTION
Currently, CASA on Rails will set the CASA Payload for an app to have the value `true` for LTI if there are no custom definitions for the LTI launch. When some payloads have this `true` value, and others have an object value, Elasticsearch fails because [an index cannot contain data of different types](http://stackoverflow.com/questions/26930587/elasticsearch-mapping-different-data-types-in-same-field).

Once this change is pulled, you'll need to shut down CASA on Rails, delete the app's index in Elasticsearch, and then start CASA on Rails again to re-initialize the index with the right type (which should be an object for this field).

The Elasticsearch index can be deleted by issuing the following command on the CASA host (needs to be done from the host because IPTables is blocking the port to the outside):

```
curl -XDELETE 'http://localhost:9200/apps'
```
