### PR TITLE
adjust production env settings to match current prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,17 +20,20 @@ Rails.application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = false
+  config.serve_static_assets = true
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  # config.assets.compile = false
 
   # Generate digests for assets URLs.
   config.assets.digest = true
+
+  # Version of your assets, change this if you want to expire all your assets.
+  config.assets.version = '1.0'
 
   # `config.assets.precompile` has moved to config/initializers/assets.rb
 


### PR DESCRIPTION
This sets prod environment file to settings used in prod. Also fixes #64, allowing anyone just checking out the repo and setting `RAILS_ENV=production` to have static resources served without requiring modifications to this file.
