### PR TITLE
add rapporteur gem to get /status.json page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,6 @@ gem 'bcrypt'
 gem 'oauth2'
 
 gem 'thin'
+
+# generates a status page at /status.json
+gem 'rapporteur'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
+    rapporteur (3.3.0)
+      i18n (~> 0.6)
     rdoc (4.1.1)
       json (~> 1.4)
     ruby-bower (0.0.1)
@@ -194,6 +196,7 @@ DEPENDENCIES
   oauth
   oauth2
   rails (= 4.1.4)
+  rapporteur
   rufus-scheduler
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
@@ -202,3 +205,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web_blocks!
+
+BUNDLED WITH
+   1.10.5

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,4 +71,6 @@ Rails.application.routes.draw do
   get 'mobile/return/(:id)', to: 'mobile#return'
   get 'mobile/abort', to: 'mobile#abort'
 
+  # get 'status.json' is used by the rapporteur gem.
+
 end


### PR DESCRIPTION
This uses the [codeschool/rapporteur](https://github.com/codeschool/rapporteur) gem to add a /status.json endpoint which serves up json ensuring the server is running. For the time being, It serves the git revision and the date/time, but it can easily be appended to ensure ActiveRecord has a db connection, and really anything that you'd want to monitor.
