### PR TITLE
add support for es yml file to overwrite default settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 # Ignore editor and environment files
 .DS_Store
 /.idea
+
+# Ignore es config file
+/config/elasticsearch.yml

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,12 +1,21 @@
 # Be sure to restart your server when you modify this file.
 
 require 'elasticsearch'
+require 'yaml'
 
-Rails.application.config.elasticsearch_client = Elasticsearch::Client.new hosts: [
-  { host: 'localhost', port: 9200 }
-]
+config = {
+	hosts: [
+	  { host: 'localhost', port: 9200 }
+	],
+	index: 'apps'
+}
 
-Rails.application.config.elasticsearch_index = 'apps'
+if File.exists?("config/elasticsearch.yml")
+  config.merge!(YAML.load_file("config/elasticsearch.yml").deep_symbolize_keys)
+end
+
+Rails.application.config.elasticsearch_client = Elasticsearch::Client.new(config)
+Rails.application.config.elasticsearch_index = config[:index]
 
 begin
   Rails.application.config.elasticsearch_client.ping


### PR DESCRIPTION
This PR adds support for a config/elasticsearch.yml file (which is specifically git ignored) that, if it exists, will use contents to overwrite the default elasticsearch client settings.

Current casa deploys with chef will blow away `initalizers/elasticsearch.rb` and replace with the old verison, so this should be perfectly safe to merge as it maintains backward compatibility for the default config and wont affect prod (but will help clean up prod when we use it instead of overwriting it!).  Boy, that was wordy.

An example `elasticsearch.yml` file I'm using on my local box:

``` yml
hosts:
  - host: '192.168.99.100'
    port: 32770

index: 'apps'
```
