### PR TITLE
Add default app order to payload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,7 @@ gem 'rapporteur'
 
 # for JSON Schema validation of payload attribute data
 gem 'json-schema', '2.5.2'
+
+group :development do
+  gem 'awesome_print'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     arel (6.0.3)
+    awesome_print (1.7.0)
     bcrypt (3.1.11)
     builder (3.2.2)
     chunky_png (1.3.5)
@@ -209,6 +210,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-session_store
+  awesome_print
   bcrypt
   coffee-rails (~> 4.0.0)
   elasticsearch
@@ -231,4 +233,4 @@ DEPENDENCIES
   web_blocks!
 
 BUNDLED WITH
-   1.11.2
+   1.15.4

--- a/app/models/casa/attribute/default_app_order.rb
+++ b/app/models/casa/attribute/default_app_order.rb
@@ -1,0 +1,12 @@
+module Casa
+  module Attribute
+    class DefaultAppOrder
+
+      cattr_reader :name, :uuid
+
+      @@name = 'default_app_order'
+      @@uuid = 'fd728bfa-93d3-4bf0-9ce2-8a1a9cf5f59c'
+
+    end
+  end
+end

--- a/app/models/casa/payload.rb
+++ b/app/models/casa/payload.rb
@@ -30,7 +30,7 @@ module Casa
             Casa::Attribute::Security.name => Casa::Attribute::Security,
             Casa::Attribute::StudentData.name => Casa::Attribute::StudentData,
             Casa::Attribute::Features.name => Casa::Attribute::Features,
-            Casa::Attribute::DefaultAppOrder.name => Casa::Attribute::DefaultAppOrder,
+            Casa::Attribute::DefaultAppOrder.name => Casa::Attribute::DefaultAppOrder
         },
         'require' => {
         }

--- a/app/models/casa/payload.rb
+++ b/app/models/casa/payload.rb
@@ -29,7 +29,8 @@ module Casa
             Casa::Attribute::Licensing.name => Casa::Attribute::Licensing,
             Casa::Attribute::Security.name => Casa::Attribute::Security,
             Casa::Attribute::StudentData.name => Casa::Attribute::StudentData,
-            Casa::Attribute::Features.name => Casa::Attribute::Features
+            Casa::Attribute::Features.name => Casa::Attribute::Features,
+            Casa::Attribute::DefaultAppOrder.name => Casa::Attribute::DefaultAppOrder,
         },
         'require' => {
         }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "bower":">=1.3.8"
+    "bower": ">=1.3.8"
   }
 }


### PR DESCRIPTION
The mobile apps need to know this in case the user resets their apps to default.